### PR TITLE
Add definitions for the main application callbacks

### DIFF
--- a/lib/callbacks.lua
+++ b/lib/callbacks.lua
@@ -4,7 +4,7 @@
 --- [View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#Program_Stucture)
 function _init() end
 
---- Called 60 times per second, provided that `_update` function does not exceed ~90% CPU
+--- Called 60 times per second, provided that the `_update` function does not exceed ~90% CPU
 --- [View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#Program_Stucture)
 function _update() end
 

--- a/lib/callbacks.lua
+++ b/lib/callbacks.lua
@@ -1,0 +1,14 @@
+---@meta
+
+--- Called after main.lua is run, but before the first call to `_update`.
+--- [View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#Program_Stucture)
+function _init() end
+
+--- Called 60 times per second, provided that `_update` function does not exceed ~90% CPU
+--- [View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#Program_Stucture)
+function _update() end
+
+--- Called each time the window manager asks for a frame.
+--- If `_update` and `_draw` combined exceed ~90% CPU, draw will be called less frequently.
+--- [View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#Program_Stucture)
+function _draw() end


### PR DESCRIPTION
`_init`, `_update`, and `_draw` all have definitions now.
As far as I can tell, the documentation doesn't show up, but it does prevent the LLS from identifying them as lowercase globals.