### PR TITLE
Allow window to be called without an argument

### DIFF
--- a/lib/windows.lua
+++ b/lib/windows.lua
@@ -48,5 +48,5 @@ function window(width, height, attribs) end
 
 --- Create a window or set its attributes
 --- [View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#window)
---- @param attribs __WindowAttribs
+--- @param attribs? __WindowAttribs
 function window(attribs) end


### PR DESCRIPTION
Providing no `attribs` is valid, and will initialize a display buffer.